### PR TITLE
Allow for property name adjustment in the LIMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ entry for further detail.
 **Integration with the openBIS LIMS**
 
 The sample information is retrieved automatically from an openBIS instance acting as LIMS. The
-configuration of the openBIS needs to make sure each sample provides a QBiC barcode (containin `Q`) and a sample status.
+configuration of the openBIS needs to make sure each sample provides a QBiC barcode (containing `Q`) and a sample status.
 Furthermore, the names of the properties providing this information needs to be provided (see [Environment Variables](#environment-variables)).
 
 * The sample status may contain values

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 <div align="center">
 
 # LIMS Sample Status Reporter
+
 <i>A command line tool to report LIMS changes to the sample-tracking service</i>.
-
-
 
 [![Build Maven Package](https://github.com/qbicsoftware/sample-status-reporter/actions/workflows/build_package.yml/badge.svg)](https://github.com/qbicsoftware/sample-status-reporter/actions/workflows/build_package.yml)
 [![Run Maven Tests](https://github.com/qbicsoftware/sample-status-reporter/actions/workflows/run_tests.yml/badge.svg)](https://github.com/qbicsoftware/sample-status-reporter/actions/workflows/run_tests.yml)
@@ -20,7 +19,7 @@
 
 As updating sample statuses in more then one place can lead to errors and frustration, automation of
 this process is deemed important. The `sample-status-reporter` automates the migration of updated
-sample statuses from an openBis LIMS to the 
+sample statuses from an openBis LIMS to the
 [sample-tracking-service](https://github.com/qbicsoftware/sample-tracking-service).
 
 **Interaction with the sample-tracking-service**
@@ -37,10 +36,10 @@ entry for further detail.
 **Integration with the openBIS LIMS**
 
 The sample information is retrieved automatically from an openBIS instance acting as LIMS. The
-configuration of the openBIS needs to make sure each sample proviedes the following properties:
+configuration of the openBIS needs to make sure each sample provides a QBiC barcode (containin `Q`) and a sample status.
+Furthermore, the names of the properties providing this information needs to be provided (see [Environment Variables](#environment-variables)).
 
-* `QBIC_BARCODE` containing `Q`
-* `SAMPLE_STATUS` containing values
+* The sample status may contain values
   from `[SAMPLE_RECEIVED, QC_PASSED, QC_FAILED, LIBRARY_PREP_FINISHED]`.
 
 This tool acts in the role of a user configured by you. Please make sure, that the configured user
@@ -97,22 +96,21 @@ Please note that this project requires `java 17`.
 
 For this application to be run the following environment variables need to be set:
 
-| Environment Variable                | Description                                                            | Default Value                          |
-|-------------------------------------|------------------------------------------------------------------------|----------------------------------------|
-| `LAST_UPDATE_FILE`                  | A path to a persistent file. The last successful run is stored here.   | `last-updated.txt `                    |
-| `LIMS_PASSWORD`                     | The password to access the OpenBiS LIMS                                |                                        |
-| `LIMS_SERVER_URL`                   | The URL to the OpenBiS LIMS API                                        |                                        |
-| `LIMS_USER`                         | The user to access the OpenBiS LIMS                                    |                                        |
-| `SAMPLE_TRACKING_AUTH_PASSWORD`     | The password for the sample tracking user                              | `astrongpassphrase! `                  |
-| `SAMPLE_TRACKING_AUTH_USER`         | The username for the sample tracking service                           | `qbic`                                 |
-| `SAMPLE_TRACKING_LOCATION_ENDPOINT` | The endpoint to list all locations. This does not contain the base url | `/locations`                           |
-| `SAMPLE_TRACKING_LOCATION_USER`     | The sample tracking user currently using the application               | `my_email@example.com`                 |
-| `SAMPLE_TRACKING_URL`               | The base URL for the sample tracking service                           | `http://localhost.de`                  |
-| `USER_DB_DIALECT`                   | The database dialect of the user database                              | `org.hibernate.dialect.MariaDBDialect` |
-| `USER_DB_DRIVER`                    | The database driver for the user database                              | `com.mysql.cj.jdbc.Driver`             |
-| `USER_DB_HOST`                      | The URL to the host of the user database containing the database name  | `localhost`                            |
-| `USER_DB_USER_NAME`                 | The database user name                                                 | `myusername`                           |
-| `USER_DB_USER_PW`                   | The database user password                                             | ` astrongpassphrase!`                  |
-
-
-
+| Environment Variable                | Description                                                                                   | Default Value                          |
+|-------------------------------------|-----------------------------------------------------------------------------------------------|----------------------------------------|
+| `LAST_UPDATE_FILE`                  | A path to a persistent file. The last successful run is stored here.                          | `last-updated.txt `                    |
+| `LIMS_PASSWORD`                     | The password to access the OpenBiS LIMS                                                       |                                        |
+| `LIMS_SERVER_URL`                   | The URL to the OpenBiS LIMS API                                                               |                                        |
+| `LIMS_USER`                         | The user to access the OpenBiS LIMS                                                           |                                        |
+| `LIMS_BARCODE_PROPERTY`             | The name of the property in the OpenBiS LIMS from which to read the QBiC barcode              |                                        |
+| `LIMS_STATUS_PROPERTY`              | The name of the property in the OpenBis LIMS from which to read the sample status information |                                        |
+| `SAMPLE_TRACKING_AUTH_PASSWORD`     | The password for the sample tracking user                                                     | `astrongpassphrase! `                  |
+| `SAMPLE_TRACKING_AUTH_USER`         | The username for the sample tracking service                                                  | `qbic`                                 |
+| `SAMPLE_TRACKING_LOCATION_ENDPOINT` | The endpoint to list all locations. This does not contain the base url                        | `/locations`                           |
+| `SAMPLE_TRACKING_LOCATION_USER`     | The sample tracking user currently using the application                                      | `my_email@example.com`                 |
+| `SAMPLE_TRACKING_URL`               | The base URL for the sample tracking service                                                  | `http://localhost.de`                  |
+| `USER_DB_DIALECT`                   | The database dialect of the user database                                                     | `org.hibernate.dialect.MariaDBDialect` |
+| `USER_DB_DRIVER`                    | The database driver for the user database                                                     | `com.mysql.cj.jdbc.Driver`             |
+| `USER_DB_HOST`                      | The URL to the host of the user database containing the database name                         | `localhost`                            |
+| `USER_DB_USER_NAME`                 | The database user name                                                                        | `myusername`                           |
+| `USER_DB_USER_PW`                   | The database user password                                                                    | ` astrongpassphrase!`                  |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ configuration of the openBIS needs to make sure each sample provides a QBiC barc
 Furthermore, the names of the properties providing this information needs to be provided (see [Environment Variables](#environment-variables)).
 
 * The sample status may contain values
-  from `[SAMPLE_RECEIVED, QC_PASSED, QC_FAILED, LIBRARY_PREP_FINISHED]`.
+  from `["Sample received", "QC passed", "QC failed", "Library completed"]`.
 
 This tool acts in the role of a user configured by you. Please make sure, that the configured user
 only sees projects where you want to propagate the status to the sample-tracking system.

--- a/src/main/groovy/life/qbic/samplestatus/reporter/api/LocationService.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/api/LocationService.groovy
@@ -18,6 +18,6 @@ interface LocationService {
      * Must not be thrown, if the internal query was successful but no matching location was found. Instead, return an {@link Optional#empty}.
      * @since 0.1.0
      */
-    Optional<Location> getUpdatingPersonLocation() throws ServiceException
+    Optional<Location> getUpdatingPersonLocation()
 
 }

--- a/src/main/groovy/life/qbic/samplestatus/reporter/commands/ReportSinceInstant.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/commands/ReportSinceInstant.groovy
@@ -82,6 +82,7 @@ class ReportSinceInstant implements Runnable {
       updatedSamples.stream()
               .filter(Result::isOk)
               .map(Result::getValue)
+              .sorted((SampleUpdate su1, SampleUpdate su2) -> su1.getModificationDate().compareTo(su2.getModificationDate()))
               .peek(it -> log.info("\tUpdating $it"))
               .forEach(statusReporter::reportSampleStatusUpdate)
       log.info("Finished processing.")

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/LastUpdateSearch.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/LastUpdateSearch.groovy
@@ -28,7 +28,8 @@ class LastUpdateSearch implements UpdateSearchService {
   }
 
   /**
-   * @inheritDocs
+   * {@inheritDoc}
+   * @return {@inheritDoc}
    */
   @Override
   Optional<Instant> getLastUpdateSearchTimePoint() {
@@ -36,7 +37,8 @@ class LastUpdateSearch implements UpdateSearchService {
   }
 
   /**
-   * @inheritDocs
+   * {@inheritDoc}
+   * @param lastSearchTimePoint {@inheritDoc}
    */
   @Override
   void saveLastSearchTimePoint(Instant lastSearchTimePoint) {

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/RealLimsQueryService.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/RealLimsQueryService.groovy
@@ -128,7 +128,7 @@ class RealLimsQueryService implements LimsQueryService {
 
     switch (updatedStatus) {
       case { it.isOk() }: return Result.of(new SampleUpdate(sample: sample, updatedStatus: updatedStatus.getValue(), modificationDate: modificationDate.toInstant())); break
-      case { it.isError() }: return Result.of(updatedStatus.getError()); break
+      case { it.isError() }: return Result.of(new RuntimeException("$sampleBarcode => ${updatedStatus.getError().getMessage()}", updatedStatus.getError())); break
       default: throw new RuntimeException("Result neither Ok nor Error. This is not expected!")
     }
   }

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/RealLimsQueryService.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/RealLimsQueryService.groovy
@@ -75,7 +75,9 @@ class RealLimsQueryService implements LimsQueryService {
     }
   }
   /**
-   * {@InheritDocs}
+   * {@inheritDoc}
+   * @param  updatedSince {@inheritDoc}
+   * @return {@inheritDoc}
    */
   @Override
   List<Result<SampleUpdate, Exception>> getUpdatedSamples(Instant updatedSince) {

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
@@ -52,6 +52,9 @@ class SampleStatusMapper implements Function<String, Result<String, Exception>> 
   }
 
   private Result<String, Exception> mapSampleStatus(String statusString) {
+    if (statusString == null) {
+      return Result.of(new MappingException("Status value is null."))
+    }
     if (statusString.isEmpty()) {
       return Result.of(new MappingException("Status value is empty."))
     }

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
@@ -13,10 +13,33 @@ import java.util.function.Function
  */
 class SampleStatusMapper implements Function<String, Result<String, Exception>> {
 
-  private static final String SAMPLE_RECEIVED = "SAMPLE_RECEIVED"
-  private static final String SAMPLE_QC_PASS = "SAMPLE_QC_PASS"
-  private static final String SAMPLE_QC_FAIL = "SAMPLE_QC_FAIL"
-  private static final String LIBRARY_PREP_FINISHED = "LIBRARY_PREP_FINISHED"
+  enum SampleStatus {
+    SAMPLE_RECEIVED("Sample received", "SAMPLE_RECEIVED"),
+    SAMPLE_QC_PASSED("QC passed", "SAMPLE_QC_PASS"),
+    SAMPLE_QC_FAILED("QC failed", "SAMPLE_QC_FAIL"),
+    LIBRARY_PREP_FINISHED("Library completed", "LIBRARY_PREP_FINISHED")
+
+
+    private final String limsStatus
+    private final String qbicStatus
+
+    private SampleStatus(String limsStatus, String qbicStatus) {
+      this.limsStatus = limsStatus
+      this.qbicStatus = qbicStatus
+    }
+
+    static Optional<SampleStatus> fromLimsStatus(String status) {
+      return Arrays.stream(values())
+              .filter(it -> it.limsStatus.equals(status))
+              .findFirst()
+    }
+
+    static Optional<SampleStatus> fromQbicStatus(String status) {
+      return Arrays.stream(values())
+              .filter(it -> it.qbicStatus.equals(status))
+              .findFirst()
+    }
+  }
 
   /**
    * <p>Tries to map a String value to a known sample status.</p>
@@ -32,20 +55,9 @@ class SampleStatusMapper implements Function<String, Result<String, Exception>> 
     if (statusString.isEmpty()) {
       return Result.of(new MappingException("Status value is empty."))
     }
-    Result<String, Exception> result
-    switch (statusString) {
-      case "SAMPLE_RECEIVED":
-        result = Result.of(SAMPLE_RECEIVED); break
-      case "QC_PASSED":
-        result = Result.of(SAMPLE_QC_PASS); break
-      case "QC_FAILED":
-        result = Result.of(SAMPLE_QC_FAIL); break
-      case "LIBRARY_PREP_FINISHED":
-        result = Result.of(LIBRARY_PREP_FINISHED); break
-      default:
-        result = Result.of(new MappingException("Cannot map unkown satus value: $statusString."))
-    }
-    return result
+    return SampleStatus.fromLimsStatus(statusString)
+            .map(it -> Result.of(it.qbicStatus))
+            .orElseGet(() -> Result.of(new MappingException("Cannot map unkown satus value: $statusString.")))
   }
 
   /**
@@ -59,5 +71,3 @@ class SampleStatusMapper implements Function<String, Result<String, Exception>> 
     }
   }
 }
-
-

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
@@ -57,7 +57,7 @@ class SampleStatusMapper implements Function<String, Result<String, Exception>> 
     }
     return SampleStatus.fromLimsStatus(statusString)
             .map(it -> Result.of(it.qbicStatus))
-            .orElseGet(() -> Result.of(new MappingException("Cannot map unkown satus value: $statusString.")))
+            .orElseGet(() -> Result.of(new MappingException("Cannot map unknown status value: $statusString.")))
   }
 
   /**

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -49,6 +49,16 @@
       "name": "databases.users.user.password",
       "type": "java.lang.String",
       "description": "Description for databases.users.user.password."
+    },
+    {
+      "name": "service.openbis.lims.sampleinformation.status",
+      "type": "java.lang.String",
+      "description": "The name of the property in the openBiS LIMS providing sample status information."
+    },
+    {
+      "name": "service.openbis.lims.sampleinformation.barcode",
+      "type": "java.lang.String",
+      "description": "The name of the property in the openBiS LIMS providing the QBiC sample barcode."
     }
   ]
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,8 @@ databases.users.user.password=${USER_DB_USER_PW:astrongpassphrase!}
 service.openbis.lims.server.api.url=${LIMS_SERVER_URL:}
 service.openbis.lims.user.name=${LIMS_USER:}
 service.openbis.lims.user.password=${LIMS_PASSWORD:}
+service.openbis.lims.sampleinformation.barcode=${LIMS_BARCODE_PROPERTY:}
+service.openbis.lims.sampleinformation.status=${LIMS_STATUS_PROPERTY:}
 # openBIS application server timeout in milliseconds
 service.openbis.server.timeout=${OPENBIS_TIMEOUT:10000}
 # File path to the text file that stores the date of the last search for updated samples


### PR DESCRIPTION
This PR introduces configurable property names for the properties taken from the configured OpenBiS LIMS.
It introduces changes to the assumed property values of the sample status.