### PR TITLE
Ignore sequencing completed status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Furthermore, the names of the properties providing this information needs to be 
 * The sample status may contain values
   from `["Sample received", "QC passed", "QC failed", "Library completed"]`.
 
+Besides that you can configure LIMS statuses this tools will ignore. For this pass a comma-separated list in the `LIMS_IGNORED_STATUSES` environment variable.
 This tool acts in the role of a user configured by you. Please make sure, that the configured user
 only sees projects where you want to propagate the status to the sample-tracking system.
 
@@ -104,6 +105,7 @@ For this application to be run the following environment variables need to be se
 | `LIMS_USER`                         | The user to access the OpenBiS LIMS                                                           |                                        |
 | `LIMS_BARCODE_PROPERTY`             | The name of the property in the OpenBiS LIMS from which to read the QBiC barcode              |                                        |
 | `LIMS_STATUS_PROPERTY`              | The name of the property in the OpenBis LIMS from which to read the sample status information |                                        |
+| `LIMS_IGNORED_STATUSES`             | A comma-separated list of LIMS sample statuses to be ignored by the reporter                  |                                        |
 | `SAMPLE_TRACKING_AUTH_PASSWORD`     | The password for the sample tracking user                                                     | `astrongpassphrase! `                  |
 | `SAMPLE_TRACKING_AUTH_USER`         | The username for the sample tracking service                                                  | `qbic`                                 |
 | `SAMPLE_TRACKING_LOCATION_ENDPOINT` | The endpoint to list all locations. This does not contain the base url                        | `/locations`                           |

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/RealLimsQueryService.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/RealLimsQueryService.groovy
@@ -11,11 +11,12 @@ import life.qbic.samplestatus.reporter.SampleUpdate
 import life.qbic.samplestatus.reporter.api.LimsQueryService
 import life.qbic.samplestatus.reporter.services.utils.SampleStatusMapper
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Component
 
 import javax.annotation.PostConstruct
 import java.time.Instant
+
+import static java.util.Objects.requireNonNull
 
 /**
  * <b>Class RealLimsQueryService</b>
@@ -27,7 +28,6 @@ import java.time.Instant
  * @since 1.0.0
  */
 @Component
-@ConfigurationProperties
 class RealLimsQueryService implements LimsQueryService {
 
   private IApplicationServerApi openBisApplicationServerApi
@@ -40,7 +40,7 @@ class RealLimsQueryService implements LimsQueryService {
 
   private SampleStatusMapper statusMapper
 
-  private List<String> ignoredStatusValues = ["Sequencing completed"]
+  private List<String> ignoredStatusValues
 
 
   /**
@@ -66,13 +66,15 @@ class RealLimsQueryService implements LimsQueryService {
                        @Value('${service.openbis.lims.server.api.url}') String applicationServerUrl,
                        @Value('${service.openbis.lims.sampleinformation.status}') String sampleStatusProperty,
                        @Value('${service.openbis.lims.sampleinformation.barcode}') String qbicBarcodeProperty,
+                       @Value('${service.openbis.lims.sampleinformation.status.ignored}') List<String> ignoredStatuses,
                        @Value('${service.openbis.server.timeout}') Integer serverTimeout) {
     this.openBisApplicationServerApi = HttpInvokerUtils.createServiceStub(
             IApplicationServerApi.class,
             applicationServerUrl + IApplicationServerApi.SERVICE_URL, serverTimeout)
     sessionToken = this.openBisApplicationServerApi.login(openbisUser, openbisPassword)
-    this.qbicBarcodeProperty = Objects.requireNonNull(qbicBarcodeProperty)
-    this.sampleStatusProperty = Objects.requireNonNull(sampleStatusProperty)
+    this.qbicBarcodeProperty = requireNonNull(qbicBarcodeProperty)
+    this.sampleStatusProperty = requireNonNull(sampleStatusProperty)
+    this.ignoredStatusValues = requireNonNull(ignoredStatuses)
     if (qbicBarcodeProperty.isEmpty()) {
       throw new IllegalArgumentException("Provided barcode property '$qbicBarcodeProperty' must not be empty.")
     }

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/RealLimsQueryService.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/RealLimsQueryService.groovy
@@ -40,6 +40,8 @@ class RealLimsQueryService implements LimsQueryService {
 
   private SampleStatusMapper statusMapper
 
+  private List<String> ignoredStatusValues = ["Sequencing completed"]
+
 
   /**
    * <b>Main configuration constructor</b>
@@ -122,7 +124,7 @@ class RealLimsQueryService implements LimsQueryService {
   private boolean hasIgnoredLimsStatus(Sample sample) {
     Map<String, String> properties = sample.getProperties()
     String sampleStatus = properties.get(sampleStatusProperty)
-    return statusMapper.isIgnoredLimsStatus(sampleStatus)
+    return ignoredStatusValues.contains(sampleStatus)
   }
 
   private Result<SampleUpdate, Exception> createSampleUpdate(Sample limsSample) {

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
@@ -2,8 +2,6 @@ package life.qbic.samplestatus.reporter.services.utils
 
 import life.qbic.samplestatus.reporter.Result
 
-import java.util.function.Function
-
 /**
  * <b>Class SampleStatusMapper<b>
  *
@@ -11,44 +9,46 @@ import java.util.function.Function
  *
  * @since 1.0.0
  */
-class SampleStatusMapper implements Function<String, Result<String, Exception>> {
+class SampleStatusMapper {
 
-  enum SampleStatus {
-    SAMPLE_RECEIVED("Sample received", "SAMPLE_RECEIVED"),
-    SAMPLE_QC_PASSED("QC passed", "SAMPLE_QC_PASS"),
-    SAMPLE_QC_FAILED("QC failed", "SAMPLE_QC_FAIL"),
-    LIBRARY_PREP_FINISHED("Library completed", "LIBRARY_PREP_FINISHED")
+  enum KnownSampleStatus {
+    SAMPLE_RECEIVED("Sample received", "SAMPLE_RECEIVED", false),
+    SAMPLE_QC_PASSED("QC passed", "SAMPLE_QC_PASS", false),
+    SAMPLE_QC_FAILED("QC failed", "SAMPLE_QC_FAIL", false),
+    LIBRARY_PREP_FINISHED("Library completed", "LIBRARY_PREP_FINISHED", false),
+    SEQUENCING_COMPLETED("Sequencing completed", "", true)
 
 
     private final String limsStatus
     private final String qbicStatus
+    private final boolean ignored
 
-    private SampleStatus(String limsStatus, String qbicStatus) {
+    private KnownSampleStatus(String limsStatus, String qbicStatus, boolean ignored) {
       this.limsStatus = limsStatus
       this.qbicStatus = qbicStatus
+      this.ignored = ignored
     }
 
-    static Optional<SampleStatus> fromLimsStatus(String status) {
+    static Optional<KnownSampleStatus> fromLimsStatus(String status) {
       return Arrays.stream(values())
               .filter(it -> it.limsStatus.equals(status))
               .findFirst()
     }
 
-    static Optional<SampleStatus> fromQbicStatus(String status) {
-      return Arrays.stream(values())
-              .filter(it -> it.qbicStatus.equals(status))
-              .findFirst()
+    private boolean isIgnored() {
+      return ignored
     }
   }
 
-  /**
-   * <p>Tries to map a String value to a known sample status.</p>
-   * @param s the String value you want to have mapped
-   * @return the mapped String value
-   */
-  @Override
-  Result<String, Exception> apply(String s) {
-    return mapSampleStatus(s)
+
+  public static boolean isIgnoredLimsStatus(String status) {
+    return KnownSampleStatus.fromLimsStatus(status)
+            .map(KnownSampleStatus::isIgnored)
+            .orElse(false)
+  }
+
+  public Result<String, Exception> limsToQbicStatus(String limsStatus) {
+    mapSampleStatus(limsStatus)
   }
 
   private Result<String, Exception> mapSampleStatus(String statusString) {
@@ -58,9 +58,9 @@ class SampleStatusMapper implements Function<String, Result<String, Exception>> 
     if (statusString.isEmpty()) {
       return Result.of(new MappingException("Status value is empty."))
     }
-    return SampleStatus.fromLimsStatus(statusString)
-            .map(it -> Result.of(it.qbicStatus))
-            .orElseGet(() -> Result.of(new MappingException("Cannot map unknown status value: $statusString.")))
+    return Result.of(KnownSampleStatus.fromLimsStatus(statusString)
+            .map(it -> it.qbicStatus)
+            .orElseGet(() -> new MappingException("Cannot map unknown status value: $statusString.")))
   }
 
   /**

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
@@ -40,13 +40,21 @@ class SampleStatusMapper {
     }
   }
 
-
+ /**
+ * @param status the lims status to be checked
+ * @return true if the status is marked as ignored; false otherwise
+ */
   public static boolean isIgnoredLimsStatus(String status) {
     return KnownSampleStatus.fromLimsStatus(status)
             .map(KnownSampleStatus::isIgnored)
             .orElse(false)
   }
 
+  /**
+   * Maps lims to qbic sample status
+   * @param limsStatus
+   * @return a result containing the mapped value or the exception that occurred.
+   */
   public Result<String, Exception> limsToQbicStatus(String limsStatus) {
     mapSampleStatus(limsStatus)
   }
@@ -65,8 +73,7 @@ class SampleStatusMapper {
 
   /**
    * <b>Class MappingException</b>
-   * <p>Small mapping exception class that can be used when sample status mapping fails</p>
-   */
+   * <p>Small mapping exception class that can be used when sample status mapping fails</p>*/
   class MappingException extends RuntimeException {
 
     MappingException(String message) {

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
@@ -11,7 +11,7 @@ import life.qbic.samplestatus.reporter.Result
  */
 class SampleStatusMapper {
 
-  enum KnownSampleStatus {
+  private final enum KnownSampleStatus {
     SAMPLE_RECEIVED("Sample received", "SAMPLE_RECEIVED"),
     SAMPLE_QC_PASSED("QC passed", "SAMPLE_QC_PASS"),
     SAMPLE_QC_FAILED("QC failed", "SAMPLE_QC_FAIL"),
@@ -25,7 +25,7 @@ class SampleStatusMapper {
       this.qbicStatus = qbicStatus
     }
 
-    static Optional<KnownSampleStatus> fromLimsStatus(String status) {
+    private static Optional<KnownSampleStatus> fromLimsStatus(String status) {
       return Arrays.stream(values())
               .filter(it -> it.limsStatus.equals(status))
               .findFirst()

--- a/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
+++ b/src/main/groovy/life/qbic/samplestatus/reporter/services/utils/SampleStatusMapper.groovy
@@ -12,21 +12,17 @@ import life.qbic.samplestatus.reporter.Result
 class SampleStatusMapper {
 
   enum KnownSampleStatus {
-    SAMPLE_RECEIVED("Sample received", "SAMPLE_RECEIVED", false),
-    SAMPLE_QC_PASSED("QC passed", "SAMPLE_QC_PASS", false),
-    SAMPLE_QC_FAILED("QC failed", "SAMPLE_QC_FAIL", false),
-    LIBRARY_PREP_FINISHED("Library completed", "LIBRARY_PREP_FINISHED", false),
-    SEQUENCING_COMPLETED("Sequencing completed", "", true)
-
+    SAMPLE_RECEIVED("Sample received", "SAMPLE_RECEIVED"),
+    SAMPLE_QC_PASSED("QC passed", "SAMPLE_QC_PASS"),
+    SAMPLE_QC_FAILED("QC failed", "SAMPLE_QC_FAIL"),
+    LIBRARY_PREP_FINISHED("Library completed", "LIBRARY_PREP_FINISHED"),
 
     private final String limsStatus
     private final String qbicStatus
-    private final boolean ignored
 
-    private KnownSampleStatus(String limsStatus, String qbicStatus, boolean ignored) {
+    private KnownSampleStatus(String limsStatus, String qbicStatus) {
       this.limsStatus = limsStatus
       this.qbicStatus = qbicStatus
-      this.ignored = ignored
     }
 
     static Optional<KnownSampleStatus> fromLimsStatus(String status) {
@@ -34,20 +30,6 @@ class SampleStatusMapper {
               .filter(it -> it.limsStatus.equals(status))
               .findFirst()
     }
-
-    private boolean isIgnored() {
-      return ignored
-    }
-  }
-
- /**
- * @param status the lims status to be checked
- * @return true if the status is marked as ignored; false otherwise
- */
-  public static boolean isIgnoredLimsStatus(String status) {
-    return KnownSampleStatus.fromLimsStatus(status)
-            .map(KnownSampleStatus::isIgnored)
-            .orElse(false)
   }
 
   /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,7 @@ service.openbis.lims.user.name=${LIMS_USER:}
 service.openbis.lims.user.password=${LIMS_PASSWORD:}
 service.openbis.lims.sampleinformation.barcode=${LIMS_BARCODE_PROPERTY:}
 service.openbis.lims.sampleinformation.status=${LIMS_STATUS_PROPERTY:}
+service.openbis.lims.sampleinformation.status.ignored=${LIMS_IGNORED_STATUSES:}
 # openBIS application server timeout in milliseconds
 service.openbis.server.timeout=${OPENBIS_TIMEOUT:10000}
 # File path to the text file that stores the date of the last search for updated samples


### PR DESCRIPTION
Introduces the concept of ignored lims sample statuses.
Ignored statuses are ignored by the reporter application and not forwarded to the sample-tracking service.